### PR TITLE
Proptests and symbol/identifier conversion

### DIFF
--- a/lib/rison.rb
+++ b/lib/rison.rb
@@ -3,6 +3,10 @@ require 'rison/parslet_transform'
 require 'rison/dump'
 
 module Rison
+  ID_CHAR_PATTERN = /[a-zA-Z_\.\/~\-0-9]/.freeze # TODO: any non-ASCII Unicode character
+  ID_START_PATTERN = /[a-zA-Z_\.\/~]/.freeze
+  ID_PATTERN = /^#{ID_START_PATTERN.source}(?:#{ID_CHAR_PATTERN.source})*$/.freeze
+
   class ParseError < StandardError; end
 
   def self.load(string)

--- a/lib/rison/dump.rb
+++ b/lib/rison/dump.rb
@@ -17,15 +17,15 @@ module Rison
 
       when FalseClass then FALSE
 
-      when Symbol then object.to_s
+      when Symbol then dump_symbol(object)
 
       when Rational then object.to_f.to_s
 
       when Numeric then object.to_s
 
-      when String then "'#{escape(object)}'"
+      when String then "'#{escape(object)}'" # TODO: maybe dump as identifier if string matches ID_PATTERN
 
-      when Hash then '(%s)' % object.map { |(k, v)| dump_pair(k, v) }.join(?,)
+      when Hash then '(%s)' % object.map { |(k, v)| dump_pair(k, v) }.join(?,) # TODO: sort keys
 
       when Array then '!(%s)' % object.map { |member| dump(member) }.join(?,)
 
@@ -34,8 +34,13 @@ module Rison
     end
   end
 
+  def self.dump_symbol(sym)
+    str = sym.to_s
+    Rison::ID_PATTERN.match(str) ? str : dump(str)
+  end
+
   def self.dump_pair(key, value)
-    key.is_a?(Symbol) ? "#{key}:#{dump(value)}" : "#{dump(key.to_s)}:#{dump(value)}"
+    key.is_a?(Symbol) ? "#{dump(key)}:#{dump(value)}" : "#{dump(key.to_s)}:#{dump(value)}"
   end
 
   def self.escape(string)

--- a/lib/rison/parslet_parser.rb
+++ b/lib/rison/parslet_parser.rb
@@ -26,9 +26,9 @@ module Rison
 
     rule(:idchars) { idchar.repeat(1) }
 
-    rule(:idchar) { match(/[a-zA-Z_\.\/~\-0-9]/) } # TODO: any non-ASCII Unicode character
+    rule(:idchar) { match(Rison::ID_CHAR_PATTERN) }
 
-    rule(:idstart) { match(/[a-zA-Z_\.\/~]/) }
+    rule(:idstart) { match(Rison::ID_START_PATTERN) }
 
     rule(:int) { (str('-').maybe >> (non_zero_digit >> digits | digit)).as(:int) }
 

--- a/lib/rison/parslet_transform.rb
+++ b/lib/rison/parslet_transform.rb
@@ -17,13 +17,13 @@ module Rison
 
     rule(int: simple(:int), frac: simple(:frac), exp: simple(:exp)) { Rison::Number(int, frac, exp) }
 
-    rule(identifier: simple(:value)) { value.to_s.to_sym }
+    rule(identifier: simple(:value)) { value.to_s }
 
     rule(chr: simple(:chr)) { chr.to_s }
 
     rule(string: subtree(:characters)) { characters.join }
 
-    rule(key: subtree(:k), value: subtree(:v)) { {k => v} }
+    rule(key: subtree(:k), value: subtree(:v)) { {k.to_sym => v} }
 
     rule(empty_object: '()') { Hash.new }
 

--- a/rison.gemspec
+++ b/rison.gemspec
@@ -12,5 +12,6 @@ Gem::Specification.new do |s|
   s.add_dependency('parslet', '~> 1.4')
   s.add_development_dependency('rake', '~> 10')
   s.add_development_dependency('minitest', '~> 5')
+  s.add_development_dependency('rantly', '~> 1.2')
   s.require_path = 'lib'
 end

--- a/spec/rison_cycle_spec.rb
+++ b/spec/rison_cycle_spec.rb
@@ -20,9 +20,10 @@ end
 
 def scalar_input_property
   freq(
-    [3, :integer],
+    [1, :integer],
     [2, :float],
-    [3, :string],
+    [2, :string],
+    [2, proc { string.to_sym }],
     [1, :boolean],
     [1, [:literal, nil]],
   )
@@ -36,9 +37,16 @@ def array_input_property(depth)
   )
 end
 
-def hash_input_property(depth)
+def hash_input_property(depth = 0)
   dict {
-    [ string, input_property(depth) ]
+    [
+      branch(
+        :string,
+        proc { string.to_sym }
+      ),
+      string
+      # input_property(depth)
+    ]
   }
 end
 
@@ -53,8 +61,9 @@ end
 def expected_decoded_form(data)
   case data
   when Deflating then data.array.map{|elem| expected_decoded_form(elem) }
-  when Hash then data.map{|key, val| [key, expected_decoded_form(val)] }.to_h
+  when Hash then data.map{|key, val| [key.to_sym, expected_decoded_form(val)] }.to_h
   when Float then Rational(data.to_s)
+  when Symbol then data.to_s
   else data
   end
 end

--- a/spec/rison_cycle_spec.rb
+++ b/spec/rison_cycle_spec.rb
@@ -1,0 +1,63 @@
+require 'minitest/autorun'
+require 'rantly/minitest_extensions'
+require 'rantly/shrinks'
+
+$:.unshift 'lib'
+
+require 'rison'
+
+MAXIMUM_DEPTH = 4
+
+def input_property(depth = 0)
+  return scalar_input_property if depth >= MAXIMUM_DEPTH
+
+  freq(
+    [4, proc { scalar_input_property }],
+    [1, proc { array_input_property(depth+1) }],
+    [1, proc { hash_input_property(depth+1) }]
+  )
+end
+
+def scalar_input_property
+  freq(
+    [3, :integer],
+    [3, :string],
+    [1, :boolean],
+    [1, [:literal, nil]],
+  )
+end
+
+def array_input_property(depth)
+  array {
+    input_property(depth)
+  }
+end
+
+def hash_input_property(depth)
+  dict {
+    [ string, input_property(depth) ]
+  }
+end
+
+def encodable_form(data)
+  data
+end
+
+def expected_decoded_form(data)
+  data
+end
+
+describe 'Rison dumping and loading' do
+  it "recreates data through dump and load" do
+    property_of { input_property }.check do |data|
+      encoded = Rison.dump(encodable_form(data))
+      decoded = Rison.load(encoded)
+
+      if data.nil?
+        assert_nil decoded
+      else
+        decoded.must_equal(expected_decoded_form(data))
+      end
+    end
+  end
+end

--- a/spec/rison_cycle_spec.rb
+++ b/spec/rison_cycle_spec.rb
@@ -53,7 +53,7 @@ end
 def encodable_form(data)
   case data
   when Deflating then data.array.map{|elem| encodable_form(elem) }
-  when Hash then data.map{|key, val| [key, encodable_form(val)] }.to_h
+  when Hash then Hash[data.map{|key, val| [key, encodable_form(val)] }]
   else data
   end
 end
@@ -61,7 +61,7 @@ end
 def expected_decoded_form(data)
   case data
   when Deflating then data.array.map{|elem| expected_decoded_form(elem) }
-  when Hash then data.map{|key, val| [key.to_sym, expected_decoded_form(val)] }.to_h
+  when Hash then Hash[data.map{|key, val| [key.to_sym, expected_decoded_form(val)] }]
   when Float then Rational(data.to_s)
   when Symbol then data.to_s
   else data

--- a/spec/rison_cycle_spec.rb
+++ b/spec/rison_cycle_spec.rb
@@ -21,6 +21,7 @@ end
 def scalar_input_property
   freq(
     [3, :integer],
+    [2, :float],
     [3, :string],
     [1, :boolean],
     [1, [:literal, nil]],
@@ -28,9 +29,11 @@ def scalar_input_property
 end
 
 def array_input_property(depth)
-  array {
-    input_property(depth)
-  }
+  Deflating.new(
+    array {
+      input_property(depth)
+    }
+  )
 end
 
 def hash_input_property(depth)
@@ -40,14 +43,25 @@ def hash_input_property(depth)
 end
 
 def encodable_form(data)
-  data
+  case data
+  when Deflating then data.array.map{|elem| encodable_form(elem) }
+  when Hash then data.map{|key, val| [key, encodable_form(val)] }.to_h
+  else data
+  end
 end
 
 def expected_decoded_form(data)
-  data
+  case data
+  when Deflating then data.array.map{|elem| expected_decoded_form(elem) }
+  when Hash then data.map{|key, val| [key, expected_decoded_form(val)] }.to_h
+  when Float then Rational(data.to_s)
+  else data
+  end
 end
 
 describe 'Rison dumping and loading' do
+  make_my_diffs_pretty!
+
   it "recreates data through dump and load" do
     property_of { input_property }.check do |data|
       encoded = Rison.dump(encodable_form(data))

--- a/spec/rison_dump_spec.rb
+++ b/spec/rison_dump_spec.rb
@@ -36,10 +36,18 @@ describe 'Rison dump method' do
     Rison.dump(Rational(9999, 100)).must_equal('99.99')
   end
 
-  it 'encodes symbols as ids' do
+  it 'encodes symbols as ids when possible' do
     Rison.dump(:a).must_equal('a')
     Rison.dump(:'a-z').must_equal('a-z')
     Rison.dump(:'domain.com').must_equal('domain.com')
+  end
+
+  it 'encodes symbols as strings when they cannot be ids' do
+    Rison.dump(:'').must_equal(%(''))
+    Rison.dump(:'0a').must_equal(%('0a'))
+    Rison.dump(:'a|').must_equal(%('a|'))
+    Rison.dump(:'-h').must_equal(%('-h'))
+    Rison.dump(:'US $10').must_equal(%('US $10'))
   end
 
   it 'encodes strings' do

--- a/spec/rison_load_spec.rb
+++ b/spec/rison_load_spec.rb
@@ -14,7 +14,7 @@ describe 'Rison load method' do
   end
 
   it 'parses nil' do
-    Rison.load('!n').must_equal(nil)
+    assert_nil Rison.load('!n')
   end
 
   it 'parses zero' do

--- a/spec/rison_load_spec.rb
+++ b/spec/rison_load_spec.rb
@@ -45,10 +45,10 @@ describe 'Rison load method' do
     Rison.load('1.5e2').must_equal(150)
   end
 
-  it 'parses ids as symbols' do
-    Rison.load('a').must_equal(:a)
-    Rison.load('a-z').must_equal(:'a-z')
-    Rison.load('domain.com').must_equal(:'domain.com')
+  it 'parses ids as strings' do
+    Rison.load('a').must_equal('a')
+    Rison.load('a-z').must_equal('a-z')
+    Rison.load('domain.com').must_equal('domain.com')
   end
 
   it 'parses strings' do
@@ -65,12 +65,13 @@ describe 'Rison load method' do
     Rison.load(%('can!'t')).must_equal("can't")
   end
 
-  it 'parses objects as hashes' do
+  it 'parses objects as hashes with symbol keys' do
     Rison.load('()').must_equal({})
     Rison.load('(a:0)').must_equal(:a => 0)
+    Rison.load('(\'a\':0)').must_equal(:a => 0)
     Rison.load('(a:0,b:1)').must_equal(:a => 0, :b => 1)
-    Rison.load('(a:0,b:foo,c:\'23skidoo\')').must_equal(:a => 0, :b => :foo, :c => '23skidoo')
-    Rison.load('(id:!n,type:/common/document)').must_equal(:id => nil, :type => :'/common/document')
+    Rison.load('(a:0,b:foo,c:\'23skidoo\')').must_equal(:a => 0, :b => 'foo', :c => '23skidoo')
+    Rison.load('(id:!n,type:/common/document)').must_equal(:id => nil, :type => '/common/document')
   end
 
   it 'parses arrays' do


### PR DESCRIPTION
This PR adds a couple things:

1. Property tests using [rantly](https://github.com/rantly-rb/rantly), which generate random data structures and then checks that encoding and decoding returns the original data.

2. These tests exposed a bug in symbol encoding; the encoder was assuming that symbols would be valid rison identifiers, but this is not guaranteed, since a symbol can contain any string value. To correct this, I moved the regexes for matching rison identifiers out into the main module, and only encode symbols as rison identifiers when they match the regex.

An implication this is that we cannot really treat rison identifiers as being a different type from quoted rison strings; they do not map 1-to-1 with ruby symbols and ruby strings, in actuality they are different encodings for the same string type. As a consequence, `load` converts all object keys to symbols, and all identifiers elsewhere to ruby strings.

I also fixed a small warning from minitest and added a note about sorting hash keys (which the rison homepage says should be done).